### PR TITLE
Add the missing v to the prometheus docker tag spec.

### DIFF
--- a/psc-prometheus/waypoint.hcl
+++ b/psc-prometheus/waypoint.hcl
@@ -83,6 +83,6 @@ variable "image" {
 
 variable "tag" {
   type = string
-  default = "2.51.0"
+  default = "v2.51.0"
 }
 


### PR DESCRIPTION
Closes #20 